### PR TITLE
Fixing pip install warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - '**/*.py'
+      - pyproject.toml
 env:
   PYTHON_VERSION: 3.8
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/workflows/codeql-analysis.yml'
       - '**/*.py'
+      - pyproject.toml
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - '**/*.py'
+      - pyproject.toml
       - '!tests/**'
 env:
   # global envs

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ __pycache__
 venv
 .coverage
 .vscode
-junit
+build
 coverage.xml
+junit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 59.4", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,9 @@ setup(
             'coverage~=6.2',
             'python-dateutil~=2.8',
             'pylint~=2.14',
-            'restructuredtext_lint~=1.3',
+            'restructuredtext_lint~=1.4',
             'setuptools~=59.4',
-            'unittest-xml-reporting~=3.0'
+            'unittest-xml-reporting~=3.2'
         ]
     },
     entry_points={
@@ -68,3 +68,4 @@ setup(
         "Topic :: Software Development :: Build Tools"
     ]
 )
+


### PR DESCRIPTION
Message:
DEPRECATION: arm-avhclient is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed.