### PR TITLE
Fix Integration Test

### DIFF
--- a/.github/workflows/caller-integration-tests.yml
+++ b/.github/workflows/caller-integration-tests.yml
@@ -1,0 +1,21 @@
+name: Caller Integration Tests
+on:
+  pull_request:
+    paths:
+      - '**/*.py'
+      - pyproject.toml
+      - '!tests/**'
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo -n $PR_NUMBER > ./pr/pr_number
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr/

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,13 +1,10 @@
 name: Integration Tests
 on:
-  pull_request:
-    paths:
-      - '**/*.py'
-      - pyproject.toml
-      - '!tests/**'
-env:
-  # global envs
-  AWS_IAM_PROFILE: ${{ secrets.AWS_IAM_PROFILE }}
+  workflow_run:
+    workflows:
+      - Caller Integration Tests
+    types:
+      - completed
 jobs:
   test_matrix:
     strategy:
@@ -29,8 +26,30 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Checkout this repo
+      - name: Download workflow artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: caller-integration-tests.yml
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Read the pr_num file
+        id: pr_num_reader
+        uses: juliangruber/read-file-action@v1.1.6
+        with:
+          path: ./pr_number/pr_number
+          trim: true
+
+      - name: Clone this repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout PR
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          gh pr checkout ${{ steps.pr_num_reader.outputs.content }}
 
       - name: Checkout AVH-GetStarted example
         uses: actions/checkout@v3
@@ -51,7 +70,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::720528183931:role/Proj-vht-assume-role
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
           aws-region: ${{ matrix.region }}
 
       - name: Run tests
@@ -61,5 +80,6 @@ jobs:
           AWS_S3_BUCKET_NAME: ${{ secrets[matrix.AWS_S3_BUCKET_NAME] }}
           AWS_SECURITY_GROUP_ID: ${{ secrets[matrix.AWS_SECURITY_GROUP_ID] }}
           AWS_SUBNET_ID: ${{ secrets[matrix.AWS_SUBNET_ID] }}
+          AWS_IAM_PROFILE: ${{ secrets.AWS_IAM_PROFILE }}
         run: |
           avhclient -b aws execute --specfile AVH-GetStarted/basic/avh.yml


### PR DESCRIPTION
Using a two-tier approach to overcome GitHub permission restriction
on pull requested-based runs.

The caller-integration-tests.yml is triggered by PRs (with limited
permission if forked), it collects the PR number to be passed to the
called integration-tests.yml (this run has full permissions, e.g.
to assume-role and consume secrets).

Caveat: The integration-tests.yml code is, by GH design, run from
base branch, not from the PR. So, changes on integration-test.yml
file only take effect when merged to the base branch (e.g. main)